### PR TITLE
fix multiple changing of AnimatedSource property to same value

### DIFF
--- a/WpfAnimatedGif/ImageBehavior.cs
+++ b/WpfAnimatedGif/ImageBehavior.cs
@@ -275,6 +275,8 @@ namespace WpfAnimatedGif
 
             var oldValue = e.OldValue as ImageSource;
             var newValue = e.NewValue as ImageSource;
+            if (ReferenceEquals(oldValue, newValue))
+                return;
             if (oldValue != null)
             {
                 imageControl.Loaded -= ImageControlLoaded;


### PR DESCRIPTION
Hi! Thanks for the good lib!
However, i ran into strange problem with non-animated images. This is steps to reproduse:
1) Create WPF window with Image
2) Set from code AnimatedSource property with NOT animated image (e.g. any png or jpg image)
3) Show window
4) Create and Show second instance of that window (OR: close first then create and show second window)
5) App crashes with 'System.ArgumentException' - The provided DependencyObject is not a context for this Freezable.
But if I set my image from XAML it works well.
While debugging I have found out that on show of second window it sets AnimatedSource property of Image second time (I have no idea why). So this is quick fix for that case.

PS i can provide sample project if you want