### PR TITLE
Added Duration to ImageAnimationController

### DIFF
--- a/WpfAnimatedGif/ImageAnimationController.cs
+++ b/WpfAnimatedGif/ImageAnimationController.cs
@@ -22,7 +22,7 @@ namespace WpfAnimatedGif
         private readonly ObjectAnimationUsingKeyFrames _animation;
         private readonly AnimationClock _clock;
         private readonly ClockController _clockController;
-        
+
         internal ImageAnimationController(Image image, ObjectAnimationUsingKeyFrames animation, bool autoStart)
         {
             _image = image;
@@ -34,9 +34,9 @@ namespace WpfAnimatedGif
 
             // ReSharper disable once PossibleNullReferenceException
             _clockController.Pause();
-            
+
             _image.ApplyAnimationClock(Image.SourceProperty, _clock);
-            
+
             if (autoStart)
                 _clockController.Resume();
         }
@@ -57,6 +57,19 @@ namespace WpfAnimatedGif
         public int FrameCount
         {
             get { return _animation.KeyFrames.Count; }
+        }
+
+        /// <summary>
+        /// Returns the number of frames in the image.
+        /// </summary>
+        public TimeSpan Duration
+        {
+            get
+            {
+                return _animation.Duration != null && _animation.Duration.HasTimeSpan
+                  ? _animation.Duration.TimeSpan
+                  : TimeSpan.Zero;
+            }
         }
 
         /// <summary>

--- a/WpfAnimatedGif/ImageAnimationController.cs
+++ b/WpfAnimatedGif/ImageAnimationController.cs
@@ -60,13 +60,13 @@ namespace WpfAnimatedGif
         }
 
         /// <summary>
-        /// Returns the number of frames in the image.
+        /// Returns the duration of the animation.
         /// </summary>
         public TimeSpan Duration
         {
             get
             {
-                return _animation.Duration != null && _animation.Duration.HasTimeSpan
+                return _animation.Duration.HasTimeSpan
                   ? _animation.Duration.TimeSpan
                   : TimeSpan.Zero;
             }


### PR DESCRIPTION
In my project I wanted to display the animated gif image for a fixed amount of loops with a progress bar that shows the progress of the animation. 

The initial method of calculating the duration of a animated gif file was taken from here:
http://web.archive.org/web/20130820015012/http://madskristensen.net/post/Examine-animated-Gife28099s-in-C.aspx

Since the duration was known internally in this library I decided to expose it via a property. The property can be consumed as follows:
`var animationController = ImageBehavior.GetAnimationController(image);`
`var duration = (int)animationController.Duration.TotalMilliseconds;`