### PR TITLE
Change WritebleBitmap to CachedBitmap

### DIFF
--- a/WpfAnimatedGif/ImageBehavior.cs
+++ b/WpfAnimatedGif/ImageBehavior.cs
@@ -500,7 +500,7 @@ namespace WpfAnimatedGif
                     PixelFormats.Pbgra32);
             bitmap.Render(visual);
 
-            var result = new WriteableBitmap(bitmap);
+            var result = new CachedBitmap(bitmap, BitmapCreateOptions.None, BitmapCacheOption.Default);
 
             if (result.CanFreeze && !result.IsFrozen)
                 result.Freeze();
@@ -678,7 +678,7 @@ namespace WpfAnimatedGif
                 PixelFormats.Pbgra32);
             bitmap.Render(visual);
 
-            var result = new WriteableBitmap(bitmap);
+            var result = new CachedBitmap(bitmap, BitmapCreateOptions.None, BitmapCacheOption.Default);
 
             if (result.CanFreeze && !result.IsFrozen)
                 result.Freeze();


### PR DESCRIPTION
Fix bug after update from 1.4.14 to 1.4.16 on some slow machines with
broken gif animation display. Change instance creation WriteableBitmap to
CachedBitmap fixes bug, and on all machines display animation works good
(as on 1.4.14 version). I ask to accept this change and publish 1.4.17
package.