### PR TITLE
Pause/Resume gif on image visibility changed

### DIFF
--- a/WpfAnimatedGif.Demo/MainWindow.xaml
+++ b/WpfAnimatedGif.Demo/MainWindow.xaml
@@ -64,6 +64,7 @@
                     <RadioButton Margin="5" Content="Specific count" IsChecked="{Binding UseSpecificRepeatCount}" />
                     <TextBox Margin="5" Text="{Binding RepeatCount}" Width="20" />
                     <CheckBox Margin="5" Content="Auto start" IsChecked="{Binding AutoStart}" />
+                    <CheckBox Margin="5" Content="Visibility" IsChecked="{Binding GifVisible}" />
                 </StackPanel>
                 
                 <StackPanel Grid.Row="1" Grid.Column="2" HorizontalAlignment="Right" Orientation="Horizontal">

--- a/WpfAnimatedGif.Demo/MainWindow.xaml.cs
+++ b/WpfAnimatedGif.Demo/MainWindow.xaml.cs
@@ -188,7 +188,19 @@ namespace WpfAnimatedGif.Demo
                 OnPropertyChanged("AutoStart");
             }
         }
-        
+
+        private bool _gifVisible = true;
+        public bool GifVisible
+        {
+            get { return _gifVisible; }
+            set
+            {
+                _gifVisible = value;
+                img.Visibility = _gifVisible ? Visibility.Visible : Visibility.Collapsed;
+
+                OnPropertyChanged("GifVisible");
+            }
+        }
 
         public event PropertyChangedEventHandler PropertyChanged;
 

--- a/WpfAnimatedGif/ImageBehavior.cs
+++ b/WpfAnimatedGif/ImageBehavior.cs
@@ -237,8 +237,8 @@ namespace WpfAnimatedGif
             EventManager.RegisterRoutedEvent(
                 "AnimationCompleted",
                 RoutingStrategy.Bubble,
-                typeof(RoutedEventHandler),
-                typeof(ImageBehavior));
+                typeof (RoutedEventHandler),
+                typeof (ImageBehavior));
 
         /// <summary>
         /// Adds a handler for the AnimationCompleted attached event.
@@ -370,7 +370,7 @@ namespace WpfAnimatedGif
             if (imageControl == null)
                 return;
 
-            bool newValue = (bool)e.NewValue;
+            bool newValue = (bool) e.NewValue;
 
             ImageSource source = GetAnimatedSource(imageControl);
             if (source != null && imageControl.IsLoaded)
@@ -421,7 +421,7 @@ namespace WpfAnimatedGif
                     if (animation.KeyFrames.Count > 0)
                     {
                         // For some reason, it sometimes throws an exception the first time... the second time it works.
-                        TryTwice(() => imageControl.Source = (ImageSource)animation.KeyFrames[0].Value);
+                        TryTwice(() => imageControl.Source = (ImageSource) animation.KeyFrames[0].Value);
                     }
                     else
                     {
@@ -782,16 +782,16 @@ namespace WpfAnimatedGif
             var metadataDelay = metadata.GetQueryOrDefault("/grctlext/Delay", 10);
             if (metadataDelay != 0)
                 delay = TimeSpan.FromMilliseconds(metadataDelay * 10);
-            var disposalMethod = (FrameDisposalMethod)metadata.GetQueryOrDefault("/grctlext/Disposal", 0);
+            var disposalMethod = (FrameDisposalMethod) metadata.GetQueryOrDefault("/grctlext/Disposal", 0);
             var frameMetadata = new FrameMetadata
-            {
-                Left = metadata.GetQueryOrDefault("/imgdesc/Left", 0),
-                Top = metadata.GetQueryOrDefault("/imgdesc/Top", 0),
-                Width = metadata.GetQueryOrDefault("/imgdesc/Width", frame.PixelWidth),
-                Height = metadata.GetQueryOrDefault("/imgdesc/Height", frame.PixelHeight),
-                Delay = delay,
-                DisposalMethod = disposalMethod
-            };
+                                {
+                                    Left = metadata.GetQueryOrDefault("/imgdesc/Left", 0),
+                                    Top = metadata.GetQueryOrDefault("/imgdesc/Top", 0),
+                                    Width = metadata.GetQueryOrDefault("/imgdesc/Width", frame.PixelWidth),
+                                    Height = metadata.GetQueryOrDefault("/imgdesc/Height", frame.PixelHeight),
+                                    Delay = delay,
+                                    DisposalMethod = disposalMethod
+                                };
             return frameMetadata;
         }
 
@@ -799,21 +799,21 @@ namespace WpfAnimatedGif
         {
             var d = gifMetadata.Descriptor;
             var frameMetadata = new FrameMetadata
-            {
-                Left = d.Left,
-                Top = d.Top,
-                Width = d.Width,
-                Height = d.Height,
-                Delay = TimeSpan.FromMilliseconds(100),
-                DisposalMethod = FrameDisposalMethod.None
-            };
+                                {
+                                    Left = d.Left,
+                                    Top = d.Top,
+                                    Width = d.Width,
+                                    Height = d.Height,
+                                    Delay = TimeSpan.FromMilliseconds(100),
+                                    DisposalMethod = FrameDisposalMethod.None
+                                };
 
             var gce = gifMetadata.Extensions.OfType<GifGraphicControlExtension>().FirstOrDefault();
             if (gce != null)
             {
                 if (gce.Delay != 0)
                     frameMetadata.Delay = TimeSpan.FromMilliseconds(gce.Delay);
-                frameMetadata.DisposalMethod = (FrameDisposalMethod)gce.DisposalMethod;
+                frameMetadata.DisposalMethod = (FrameDisposalMethod) gce.DisposalMethod;
             }
             return frameMetadata;
         }


### PR DESCRIPTION
Chnages related to issue #37.

I encountered the same problem in my project when used your lib. Since my app was used on the slower computers and several gifs was in UI in same time (but only one was visible at once), this fix was critical for me.

It's my first pr from the fork, so let me know if I have to change something.